### PR TITLE
Improve battery debug logging

### DIFF
--- a/include/BatteryMonitor.h
+++ b/include/BatteryMonitor.h
@@ -53,6 +53,9 @@ public:
     String getDailyStatsJSON() const;
     String getDailyStatsCompact() const;
 
+    // Debug control
+    void enableDebug(bool enable);
+
 private:
     float takeSingleReading();
     float getMovingAverage() const;
@@ -97,6 +100,11 @@ private:
     float _dailySumSOC;
 
     unsigned long _dailyCount;
+
+    // Debug helpers
+    bool _debug;
+    unsigned long _lastDebugPrint;
+    float _lastRawAvg;
 };
 
 extern BatteryMonitor battery;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@ void setup() {
 
     // display.setup();
     battery.begin();
+    battery.enableDebug(true);
 
 
     device = new Receiver();


### PR DESCRIPTION
## Summary
- add optional battery debug logging
- print raw ADC readings when debug enabled
- limit battery debug output to once per second

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_688c4267b780832b8fa40a3c036e2a5e