### PR TITLE
Fix ADC attenuation for battery monitor

### DIFF
--- a/src/BatteryMonitor.cpp
+++ b/src/BatteryMonitor.cpp
@@ -1,4 +1,5 @@
 #include "BatteryMonitor.h"
+#include <esp32-hal-adc.h>
 
 // Global instance
 BatteryMonitor battery(2, 27000.0, 100000.0, 3.3, 20);
@@ -54,6 +55,7 @@ float BatteryMonitor::takeSingleReading() {
 
 void BatteryMonitor::begin() {
     analogReadResolution(12);
+    analogSetPinAttenuation(_adcPin, ADC_11db);
     for (int i = 0; i < _numSamples; i++) {
         _sampleBuffer[i] = takeSingleReading();
     }


### PR DESCRIPTION
## Summary
- set ADC attenuation to 11 dB so the ADC can read the full battery range
- include esp32-hal-adc header

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_688c47ae3980832b82afb5cb3fe8d8d0