### PR TITLE
Initialize ADC pin for accurate battery reading

### DIFF
--- a/src/BatteryMonitor.cpp
+++ b/src/BatteryMonitor.cpp
@@ -54,7 +54,9 @@ float BatteryMonitor::takeSingleReading() {
 }
 
 void BatteryMonitor::begin() {
+    pinMode(_adcPin, INPUT);
     analogReadResolution(12);
+    adcAttachPin(_adcPin);
     analogSetPinAttenuation(_adcPin, ADC_11db);
     for (int i = 0; i < _numSamples; i++) {
         _sampleBuffer[i] = takeSingleReading();


### PR DESCRIPTION
## Summary
- attach ADC pin before sampling the battery voltage

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_688c4b5ee25c832ba6e591fcae0c438e