### PR TITLE
Adjust battery divider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # esp32-c3-SX1262-LoRa-Receiver
 LoRa SX1262 receiver component tailored for the ESP32 C3 with an 18650 battery management board.
+
+## Battery voltage divider
+
+The ADC on the ESP32 is not very linear near 0 or full scale. To keep
+measurements in the reliable range it uses a voltage divider on the
+battery input. The code assumes ~68&nbsp;kΩ from the battery positive
+to the ADC pin and 100&nbsp;kΩ from the pin to ground. With a fully
+charged cell (~4.2&nbsp;V) the ADC sees about 2.5&nbsp;V which is well inside
+the 11&nbsp;dB attenuation range.

--- a/src/BatteryMonitor.cpp
+++ b/src/BatteryMonitor.cpp
@@ -3,7 +3,11 @@
 #include "device-config.h"
 
 // Global instance
-BatteryMonitor battery(BATTERY_VOLTAGE_PIN, 27000.0, 100000.0, 3.3, 20);
+// Use a divider that keeps the ADC reading well away from the
+// non-linear region near 0 and full scale (~100-3900 counts).
+// 68k on the high side and 100k on the low side give about 2.5 V
+// at 4.2 V battery voltage when using 11 dB attenuation.
+BatteryMonitor battery(BATTERY_VOLTAGE_PIN, 68000.0, 100000.0, 3.3, 20);
 
 struct VoltageSOC {
     float voltage;


### PR DESCRIPTION
## Summary
- keep the ADC in its reliable range by using 68k/100k divider
- document the expected hardware values

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_688c4f99036c832ba78c52e59fadd793