### PR TITLE
Fix ADC readings with calibration

### DIFF
--- a/src/BatteryMonitor.cpp
+++ b/src/BatteryMonitor.cpp
@@ -37,20 +37,23 @@ BatteryMonitor::BatteryMonitor(uint8_t adcPin, float r1, float r2, float vRef, i
 }
 
 float BatteryMonitor::takeSingleReading() {
-    long sum = 0;
+    long sumRaw = 0;
+    long sumMilli = 0;
     const int quickSamples = 5;
     unsigned long now = millis();
     bool doPrint = _debug && (now - _lastDebugPrint >= 1000);
     for (int i = 0; i < quickSamples; i++) {
         int raw = analogRead(_adcPin);
-        sum += raw;
+        int mv = analogReadMilliVolts(_adcPin);
+        sumRaw += raw;
+        sumMilli += mv;
         if (doPrint) {
             Serial.printf("adc[%d]=%d\n", i, raw);
         }
         delay(3);
     }
-    _lastRawAvg = sum / (float)quickSamples;
-    float vOut = _lastRawAvg * (_vRef / 4095.0);
+    _lastRawAvg = sumRaw / (float)quickSamples;
+    float vOut = (sumMilli / (float)quickSamples) / 1000.0;
     float vBat = vOut * ((_r1 + _r2) / _r2);
     if (doPrint) {
         Serial.printf("avgRaw: %.1f vOut: %.3f vBat: %.3f\n", _lastRawAvg, vOut, vBat);


### PR DESCRIPTION
## Summary
- use `analogReadMilliVolts` to obtain calibrated voltage measurements

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_688c66c63a18832bb959c427baf6fffc